### PR TITLE
Akeneo Job Handler

### DIFF
--- a/Est/Handler/Akeneo/AbstractDatabase.php
+++ b/Est/Handler/Akeneo/AbstractDatabase.php
@@ -35,7 +35,13 @@ abstract class Est_Handler_Akeneo_AbstractDatabase extends Est_Handler_AbstractD
     {
         // Get Yml Reader if not already present
         if (!class_exists('Spyc')) {
-            require_once __DIR__ . '/../../../vendor/mustangostang/spyc/Spyc.php';
+            $currentPath = __DIR__;
+            $vendorPos = strpos(strtolower($currentPath), 'vendor');
+            if (!$vendorPos) {
+                throw new Exception("Composer Vendor Directory not found in current Path, needed to require Spyc.");
+            }
+            $rootPath = substr($currentPath, 0, $vendorPos);
+            require_once $rootPath . '/vendor/mustangostang/spyc/Spyc.php';
         }
         $localYmlFile = 'app/config/parameters.yml';
 

--- a/Est/Handler/Akeneo/AbstractDatabase.php
+++ b/Est/Handler/Akeneo/AbstractDatabase.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Abstract magento database handler class
+ *
+ * @author Dmytro Zavalkin <dmytro.zavalkin@aoe.com>
+ */
+abstract class Est_Handler_Akeneo_AbstractDatabase extends Est_Handler_AbstractDatabase
+{
+    /**@+
+     * Actions to apply on row
+     *
+     * @var string
+     */
+    const ACTION_NO_ACTION = 0;
+    const ACTION_INSERT = 1;
+    const ACTION_UPDATE = 2;
+    const ACTION_DELETE = 3;
+    /**@-*/
+
+    /**
+     * Table prefix
+     *
+     * @var string
+     */
+    protected $_tablePrefix = '';
+
+    /**
+     * Read database connection parameters from local.xml file
+     *
+     * @return array
+     * @throws Exception
+     */
+    protected function _getDatabaseConnectionParameters()
+    {
+        // Get Yml Reader if not already present
+        if (!class_exists('Spyc')) {
+            require_once __DIR__ . '/../../../vendor/mustangostang/spyc/Spyc.php';
+        }
+        $localYmlFile = 'app/config/parameters.yml';
+
+        if (!is_file($localYmlFile)) {
+            throw new Exception(sprintf('File "%s" not found', $localYmlFile));
+        }
+
+        $config = spyc_load_file($localYmlFile);
+
+        if ($config === false) {
+            throw new Exception(sprintf('Could not load yml file "%s"', $localYmlFile));
+        }
+
+        return array(
+            'host'     => (string) $config['parameters']['database_host'],
+            'database' => (string) $config['parameters']['database_name'],
+            'username' => (string) $config['parameters']['database_user'],
+            'password' => (string) $config['parameters']['database_password']
+        );
+    }
+
+    /**
+     * @param string $table
+     * @throws Exception
+     */
+    protected function _checkIfTableExists($table)
+    {
+        $result = $this->getDbConnection()
+                       ->query("SHOW TABLES LIKE \"{$this->_tablePrefix}{$table}\"");
+        if ($result->rowCount() == 0) {
+            throw new Exception("Table \"{$this->_tablePrefix}{$table}\" doesn't exist");
+        }
+    }
+
+    /**
+     * Get first row query
+     *
+     * @param string $query
+     * @param array $sqlParameters
+     * @return mixed
+     */
+    protected function _getFirstRow($query, array $sqlParameters)
+    {
+        $statement = $this->getDbConnection()->prepare($query);
+        $statement->execute($sqlParameters);
+        $statement->setFetchMode(PDO::FETCH_ASSOC);
+
+        return $statement->fetch();
+    }
+
+    /**
+     * Process delete query
+     *
+     * @param string $query
+     * @param array $sqlParameters
+     * @throws Exception
+     */
+    protected function _processDelete($query, array $sqlParameters)
+    {
+        $pdoStatement = $this->getDbConnection()->prepare($query);
+        $result       = $pdoStatement->execute($sqlParameters);
+
+        if ($result === false) {
+            throw new Exception('Error while deleting rows');
+        }
+
+        $rowCount = $pdoStatement->rowCount();
+        if ($rowCount > 0) {
+            $this->addMessage(new Est_Message(sprintf('Deleted "%s" row(s)', $rowCount)));
+        } else {
+            $this->addMessage(new Est_Message('No rows deleted.', Est_Message::SKIPPED));
+        }
+    }
+
+    /**
+     * Process insert query
+     *
+     * @param string $query
+     * @param array $sqlParameters
+     * @throws Exception
+     */
+    protected function _processInsert($query, array $sqlParameters)
+    {
+        $result = $this->getDbConnection()
+            ->prepare($query)
+            ->execute($sqlParameters);
+
+        if ($result === false) {
+            // TODO: include speaking error message
+            throw new Exception('Error while updating value');
+        }
+
+        $this->addMessage(new Est_Message(sprintf('Inserted new value "%s"', $this->value)));
+    }
+
+    /**
+     * Process update query
+     *
+     * @param string $query
+     * @param array $sqlParameters
+     * @param string $oldValue
+     * @throws Exception
+     */
+    protected function _processUpdate($query, array $sqlParameters, $oldValue)
+    {
+        $result = $this->getDbConnection()
+            ->prepare($query)
+            ->execute($sqlParameters);
+
+        if ($result === false) {
+            // TODO: include speaking error message
+            throw new Exception('Error while updating value');
+        }
+
+        $this->addMessage(new Est_Message(sprintf('Updated value from "%s" to "%s"',
+            $oldValue,
+            $this->value))
+        );
+    }
+}

--- a/Est/Handler/Akeneo/BatchJobInstanceData.php
+++ b/Est/Handler/Akeneo/BatchJobInstanceData.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Parameters
+ *
+ * - jobCode
+ * - key
+ */
+class Est_Handler_Akeneo_BatchJobInstanceData extends Est_Handler_Akeneo_AbstractDatabase
+{
+    /**
+     * Akeneo Export Job Config Table
+     * @var string
+     */
+    private $_tableName = 'akeneo_batch_job_instance';
+    /**
+     * Field where serialized configuration is stored
+     * @var string
+     */
+    private $_configField = 'rawConfiguration';
+
+    protected function _apply()
+    {
+        $this->_checkIfTableExists($this->_tableName);
+
+        $jobCode = $this->param1;
+        $key     = $this->param2;
+
+        $sqlParameters = array(
+            ':code' => $jobCode
+        );
+
+        // Decide on Action, skipping Insert
+        if (strtolower(trim($this->value)) == '--delete--') {
+            $action = self::ACTION_DELETE;
+        } else {
+            $action = self::ACTION_UPDATE;
+        }
+
+        $query = 'SELECT `'.$this->_configField.'` FROM `' . $this->_tablePrefix . $this->_tableName . '` WHERE `code` LIKE :code';
+        $firstRow = $this->_getFirstRow($query, $sqlParameters);
+
+        if ($firstRow === false) {
+            $this->addMessage(
+                new Est_Message('No matching rows found in the db', Est_Message::SKIPPED)
+            );
+        } else {
+            $configData = unserialize($firstRow[$this->_configField]);
+
+            switch ($action) {
+                case self::ACTION_DELETE:
+                    // Deletes the export job -> possibly necessary in some environments
+                    $configData[$key] = '';
+                    $query = 'DELETE FROM `' . $this->_tablePrefix . $this->_tableName . '` WHERE `code` LIKE :code';
+                    $this->_processDelete($query, $sqlParameters);
+                    break;
+                case self::ACTION_UPDATE:
+                    // Replaces a value in the given export job configuration
+                    $configData[$key] = $this->value;
+                    $sqlParameters[':value'] = serialize($configData);
+                    $query = 'UPDATE `' . $this->_tablePrefix . $this->_tableName . '` SET `' . $this->_configField . '` = :value WHERE `code` LIKE :code';
+                    $this->_processUpdate($query, $sqlParameters, $configData);
+                    break;
+                case self::ACTION_NO_ACTION;
+                default:
+                    break;
+            }
+        }
+
+        $this->destroyDb();
+
+        return true;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Example
     * Param3: not used
     * Value: sourceFile path
 
+* **Est_Handler_Akeneo_BatchJobInstanceData**: Changes values of akeneo_batch_job_instance table in a Akeneo instance. It reads its database parameters from app/config/parameters.yml - therefore it needs to be placed after any adjustments of DB credentials.
+
+    * Param1: jobcode ('csv_products_export', 'magento_attributes_export', etc.)
+    * Param2: key (key of the serialized configuration value to replace)
+    * Param3: not used
+
+    * Special features:
+        * If the value field of a row for the current environment is `--delete--` the matched export job will be deleted
 
 ## Special Features
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require":{
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "mustangostang/spyc": "0.5.*@dev"
     },
     "bin": [
         "value.php",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"jadhub/envsettingstool",
+    "name":"aoepeople/envsettingstool",
     "description":"Environment Settings Tool",
     "minimum-stability":"dev",
     "license":"GPL v3",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":"aoepeople/envsettingstool",
+    "name":"jadhub/envsettingstool",
     "description":"Environment Settings Tool",
     "minimum-stability":"dev",
     "license":"GPL v3",


### PR DESCRIPTION
I would like to add capability to configure Akeneo DB Entries for Export Job Configuration (Case: Makeing the Magento Export Endpoint configurable by Environment, but this could apply to any setting of an Export Job). The Akeneo PIM stores the DB Access Info in a yml File (Symfony Based, similar mechanism as seen in Magento) and saves Export Job Info in a specific Table (again, as specific as Magentos config data table).

Added Spyc as a composer requirement to have an easy method to read yml Files.