### PR TITLE
Add more verbose message for missing settings file

### DIFF
--- a/Est/Processor.php
+++ b/Est/Processor.php
@@ -44,7 +44,7 @@ class Est_Processor {
             throw new InvalidArgumentException('No settings file set.');
         }
         if (!file_exists($settingsFilePath)) {
-            throw new InvalidArgumentException('Could not read settings file.');
+            throw new InvalidArgumentException('Could not read settings file. Working dir: ' . getcwd() . ' file path: ' . $settingsFilePath);
         }
 
         $this->environment = $environment;


### PR DESCRIPTION
Add file path and current working directory to the exception, to ease debugging.