### PR TITLE
core_config_data handler for Magento 2

### DIFF
--- a/Est/Handler/Magento2/AbstractDatabase.php
+++ b/Est/Handler/Magento2/AbstractDatabase.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * abstract Magento 2 database handler class
+ *
+ * @author Christoph Frenes <c.frenes@reply.de>
+ */
+abstract class Est_Handler_Magento2_AbstractDatabase
+    extends Est_Handler_Magento_AbstractDatabase
+{
+    /**
+     * @var string
+     */
+    protected $_dbHost;
+
+    /**
+     * @var string
+     */
+    protected $_dbUser;
+
+    /**
+     * @var string
+     */
+    protected $_dbPassword;
+
+    /**
+     * @var string
+     */
+    protected $_dbDatabase;
+
+    /**
+     * Read database connection parameters from env.php file
+     *
+     * @return array
+     * @throws Exception
+     */
+    protected function _getDatabaseConnectionParameters()
+    {
+        $dbCredentialFile = 'app/etc/env.php';
+
+        if (!is_file($dbCredentialFile)) {
+            throw new Exception(
+                sprintf('File "%s" not found', $dbCredentialFile)
+            );
+        }
+
+        $envArray = file_get_contents($dbCredentialFile);
+
+        require $this->getComposerAutoloaderFile();
+        $phpParser = new PhpParser\Parser(new PhpParser\Lexer);
+
+        try {
+            $envConfig = $phpParser->parse($envArray);
+
+            foreach ($envConfig[0]->expr->items AS $mainNode) {
+                if ($mainNode->key->value == 'db') {
+                    foreach ($mainNode->value->items AS $dbNode) {
+                        if ($dbNode->key->value == 'table_prefix') {
+                            $this->_tablePrefix = (string)$dbNode->value->value;
+                        }
+
+                        if ($dbNode->key->value == 'connection') {
+                            foreach ($dbNode->value->items AS $conNode) {
+                                if ($conNode->key->value == 'default') {
+                                    foreach (
+                                        $conNode->value->items AS $valueNode
+                                    ) {
+                                        if ($valueNode->key->value
+                                            == 'host') {
+                                            $this->_dbHost
+                                                = $valueNode->value->value;
+                                        }
+
+                                        if ($valueNode->key->value
+                                            == 'username'
+                                        ) {
+                                            $this->_dbUser
+                                                = $valueNode->value->value;
+                                        }
+
+                                        if ($valueNode->key->value
+                                            == 'password'
+                                        ) {
+                                            $this->_dbPassword
+                                                = $valueNode->value->value;
+                                        }
+
+                                        if ($valueNode->key->value
+                                            == 'dbname'
+                                        ) {
+                                            $this->_dbDatabase
+                                                = $valueNode->value->value;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    break;
+                }
+            }
+        } catch (Error $e) {
+            throw new Exception(
+                sprintf('File "%s" could not be parsed', $dbCredentialFile)
+            );
+        }
+
+        return array(
+            'host'     => (string)$this->_dbHost,
+            'database' => (string)$this->_dbDatabase,
+            'username' => (string)$this->_dbUser,
+            'password' => (string)$this->_dbPassword
+        );
+    }
+
+    protected function getComposerAutoloaderFile()
+    {
+        return sprintf(
+            '%s%sautoload.php',
+            dirname(dirname(dirname(dirname(dirname(dirname(__FILE__)))))),
+            DIRECTORY_SEPARATOR
+        );
+    }
+}

--- a/Est/Handler/Magento2/CoreConfigData.php
+++ b/Est/Handler/Magento2/CoreConfigData.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Parameters
+ * (copy of Magento 1 file)
+ *
+ * - scope
+ * - scopeId
+ * - path
+ */
+class Est_Handler_Magento2_CoreConfigData
+    extends Est_Handler_Magento2_AbstractDatabase
+{
+    /**
+     * Protected method that actually applies the settings. This method is implemented in the inheriting classes and
+     * called from ->apply
+     *
+     * @throws Exception
+     * @return bool
+     */
+    protected function _apply()
+    {
+        $this->_checkIfTableExists('core_config_data');
+
+        $scope = $this->param1;
+        $scopeId = $this->param2;
+        $path = $this->param3;
+
+        $sqlParameters = $this->_getSqlParameters($scope, $scopeId, $path);
+        $containsPlaceholder = $this->_containsPlaceholder($sqlParameters);
+        $action = self::ACTION_NO_ACTION;
+
+        if (strtolower(trim($this->value)) == '--delete--') {
+            $action = self::ACTION_DELETE;
+        } else {
+            $query = 'SELECT `value` FROM `' . $this->_tablePrefix
+                . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
+            $firstRow = $this->_getFirstRow($query, $sqlParameters);
+
+            if ($containsPlaceholder) {
+                // scope, scope_id or path contains '%' char - we can't build an insert query, only update is possible
+                if ($firstRow === false) {
+                    $this->addMessage(
+                        new Est_Message(
+                            'Trying to update using placeholders but no rows found in the db',
+                            Est_Message::SKIPPED
+                        )
+                    );
+                } else {
+                    $action = self::ACTION_UPDATE;
+                }
+            } else {
+                if ($firstRow === false) {
+                    $action = self::ACTION_INSERT;
+                } elseif ($firstRow['value'] == $this->value) {
+                    $this->addMessage(
+                        new Est_Message(
+                            sprintf(
+                                'Value "%s" is already in place. Skipping.',
+                                $firstRow['value']
+                            ), Est_Message::SKIPPED
+                        )
+                    );
+                } else {
+                    $action = self::ACTION_UPDATE;
+                }
+            }
+        }
+
+        switch ($action) {
+            case self::ACTION_DELETE:
+                $query = 'DELETE FROM `' . $this->_tablePrefix
+                    . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
+                $this->_processDelete($query, $sqlParameters);
+                break;
+            case self::ACTION_INSERT:
+                $sqlParameters[':value'] = $this->value;
+                $query = 'INSERT INTO `' . $this->_tablePrefix
+                    . 'core_config_data` (`scope`, `scope_id`, `path`, value) VALUES (:scope, :scopeId, :path, :value)';
+                $this->_processInsert($query, $sqlParameters);
+                break;
+            case self::ACTION_UPDATE:
+                $sqlParameters[':value'] = $this->value;
+                $query = 'UPDATE `' . $this->_tablePrefix
+                    . 'core_config_data` SET `value` = :value WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
+                $this->_processUpdate(
+                    $query, $sqlParameters, $firstRow['value']
+                );
+                break;
+            case self::ACTION_NO_ACTION;
+            default:
+                break;
+        }
+
+        $this->destroyDb();
+
+        return true;
+    }
+
+    /**
+     * Protected method that actually extracts the settings. This method is implemented in the inheriting classes and
+     * called from ->extract and only echos constructed csv
+     */
+    protected function _extract()
+    {
+        $this->_checkIfTableExists('core_config_data');
+
+        $scope = $this->param1;
+        $scopeId = $this->param2;
+        $path = $this->param3;
+
+        $sqlParameters = $this->_getSqlParameters($scope, $scopeId, $path);
+
+        $query = 'SELECT scope, scope_id, path, value FROM `'
+            . $this->_tablePrefix
+            . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
+
+        return $this->_outputQuery($query, $sqlParameters);
+    }
+
+    /**
+     * Constructs the sql parameters
+     *
+     * @param string $scope
+     * @param string $scopeId
+     * @param string $path
+     *
+     * @return array
+     * @throws Exception
+     */
+    protected function _getSqlParameters($scope, $scopeId, $path)
+    {
+        if (empty($scope)) {
+            throw new Exception("No scope found");
+        }
+        if (is_null($scopeId)) {
+            throw new Exception("No scopeId found");
+        }
+        if (empty($path)) {
+            throw new Exception("No path found");
+        }
+
+        if (!in_array($scope, array('default', 'stores', 'websites', '%'))) {
+            throw new Exception(
+                "Scope must be 'default', 'stores', 'websites', or '%'"
+            );
+        }
+
+        if ($scope == 'default') {
+            $scopeId = 0;
+        }
+
+        if ($scope == 'stores' && !is_numeric($scopeId) && $scopeId !== '%') {
+            // do a store code lookup
+            $code = $scopeId;
+            $scopeId = $this->_getStoreIdFromCode($code);
+            $this->addMessage(
+                new Est_Message(
+                    "Found store id '$scopeId' for code '$code'",
+                    Est_Message::INFO
+                )
+            );
+        }
+
+        if ($scope == 'websites' && !is_numeric($scopeId) && $scopeId !== '%') {
+            // do a website code lookup
+            $code = $scopeId;
+            $scopeId = $this->_getWebsiteIdFromCode($code);
+            $this->addMessage(
+                new Est_Message(
+                    "Found website id '$scopeId' for code '$code'",
+                    Est_Message::INFO
+                )
+            );
+        }
+
+        return array(
+            ':scope' => $scope,
+            ':scopeId' => $scopeId,
+            ':path' => $path
+        );
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example
     * Param2: XPath
     * Param3: not used
 
-* **Est_Handler_Magento_CoreConfigData**: Changes values of core_config_data table in a Magento instance. It reads its database parameters from app/etc/local.xml - therefore it needs to be placed after any adjustments of DB credentials.
+* **Est_Handler_Magento_CoreConfigData** or **Est_Handler_Magento2_CoreConfigData**: Changes values of core_config_data table in a Magento 1 or 2 instance. It reads its database parameters from app/etc/local.xml or app/etc/env.php - therefore it needs to be placed after any adjustments of DB credentials.
 
     * Param1: scope ('default', 'stores', 'websites', or '%')
     * Param2: scopeid (store id, store code, website id, website code, 0 for default scope or '%')

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require":{
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "nikic/php-parser": "v1.4.1"
     },
     "bin": [
         "value.php",


### PR DESCRIPTION
The database credentials are stored in "app/etc.env.php" in Magento 2. I added a new handler (Est_Handler_Magento2_CoreConfigData) and a PHP parser dependency to address that.

It might be not the best idea to have a full copy of 'Est_Handler_Magento_CoreConfigData' in the Magento 2 sphere but that could be the topic of some refactoring.