### PR TITLE
Allow using a SQL NULL with core_config_data handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.3
   - 5.4
   - 5.5
 script:

--- a/Est/Handler/Magento/CoreConfigData.php
+++ b/Est/Handler/Magento/CoreConfigData.php
@@ -51,7 +51,7 @@ class Est_Handler_Magento_CoreConfigData extends Est_Handler_Magento_AbstractDat
             } else {
                 if ($firstRow === false) {
                      $action = self::ACTION_INSERT;
-                } elseif ($firstRow['value'] == $this->value) {
+                } elseif ($firstRow['value'] === $this->value) {
                     $this->addMessage(
                         new Est_Message(sprintf('Value "%s" is already in place. Skipping.', $firstRow['value']), Est_Message::SKIPPED)
                     );

--- a/Est/Handler/Magento/CoreConfigData.php
+++ b/Est/Handler/Magento/CoreConfigData.php
@@ -34,11 +34,6 @@ class Est_Handler_Magento_CoreConfigData extends Est_Handler_Magento_AbstractDat
             $query = 'SELECT `value` FROM `' . $this->_tablePrefix . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
             $firstRow = $this->_getFirstRow($query, $sqlParameters);
 
-            // use a real NULL value instead of a string
-            if (strtolower(trim($this->value)) === 'null') {
-                $this->value = null;
-            }
-
             if ($containsPlaceholder) {
                 // scope, scope_id or path contains '%' char - we can't build an insert query, only update is possible
                 if ($firstRow === false) {
@@ -61,18 +56,23 @@ class Est_Handler_Magento_CoreConfigData extends Est_Handler_Magento_AbstractDat
             }
         }
 
+        if (strtolower(trim($this->value)) === 'null') {
+            // use a real NULL value instead of a string
+            $sqlParameters[':value'] = null;
+        } else {
+            $sqlParameters[':value'] = $this->value;
+        }
+
         switch ($action) {
             case self::ACTION_DELETE:
                 $query = 'DELETE FROM `' . $this->_tablePrefix . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
                 $this->_processDelete($query, $sqlParameters);
                 break;
             case self::ACTION_INSERT:
-                $sqlParameters[':value'] = $this->value;
                 $query = 'INSERT INTO `' . $this->_tablePrefix . 'core_config_data` (`scope`, `scope_id`, `path`, value) VALUES (:scope, :scopeId, :path, :value)';
                 $this->_processInsert($query, $sqlParameters);
                 break;
             case self::ACTION_UPDATE:
-                $sqlParameters[':value'] = $this->value;
                 $query = 'UPDATE `' . $this->_tablePrefix . 'core_config_data` SET `value` = :value WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
                 $this->_processUpdate($query, $sqlParameters, $firstRow['value']);
                 break;

--- a/Est/Handler/Magento/CoreConfigData.php
+++ b/Est/Handler/Magento/CoreConfigData.php
@@ -34,7 +34,7 @@ class Est_Handler_Magento_CoreConfigData extends Est_Handler_Magento_AbstractDat
             $query = 'SELECT `value` FROM `' . $this->_tablePrefix . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
             $firstRow = $this->_getFirstRow($query, $sqlParameters);
 
-            // use a true NULL value instead of a string
+            // use a real NULL value instead of a string
             if (strtolower(trim($this->value)) === 'null') {
                 $this->value = null;
             }

--- a/Est/Handler/Magento/CoreConfigData.php
+++ b/Est/Handler/Magento/CoreConfigData.php
@@ -34,6 +34,11 @@ class Est_Handler_Magento_CoreConfigData extends Est_Handler_Magento_AbstractDat
             $query = 'SELECT `value` FROM `' . $this->_tablePrefix . 'core_config_data` WHERE `scope` LIKE :scope AND `scope_id` LIKE :scopeId AND `path` LIKE :path';
             $firstRow = $this->_getFirstRow($query, $sqlParameters);
 
+            // use a true NULL value instead of a string
+            if (strtolower(trim($this->value)) === 'null') {
+                $this->value = null;
+            }
+
             if ($containsPlaceholder) {
                 // scope, scope_id or path contains '%' char - we can't build an insert query, only update is possible
                 if ($firstRow === false) {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Example
 
     * Special features:
         * If the value field of a row for the current environment is `--delete--` the matched row will be deleted
+        * If the value field of a row for the current environment is `null` the row will have a value of [NULL (SQL)](https://en.wikipedia.org/wiki/Null_(SQL))
         * param1, param2, or param3 can use the wildcard `%` instead a concrete values. This will make EnvSettingsTool apply the value to multiple existing rows.
         * If scope is `stores` the scope id can be a store code instead of a store id.
         * If scope is `website` the scope id can be a website code instead of a website id.
@@ -114,7 +115,7 @@ Example
     * Param2: not used
     * Param3: not used
     * Value: sourceFile path
-    
+
 * **Est_Handler_Magento_EavEntityStore**: Sets a predefined increment prefix. The last increment id will be set to <store-id><prefix>00000000.
 
     * Param1: entity type code or entity type id
@@ -127,10 +128,10 @@ Example
     * Param2: Email
     * Param3: Rolename
     * Value: 1=enabled, 0=disabled
-    
+
 * **Est_Handler_Magento_StoreActivate**: Enables/disables an existing store
 
-    * Param1: store id or code 
+    * Param1: store id or code
     * Param2: not used
     * Param3: not used
     * Value: 0 for disable, 1 for enable
@@ -179,7 +180,7 @@ The special syntax `###FILE:filename###` allows to read the content of a file an
 Example:
 
     Est_Handler_XmlFile('app/etc/local.xml', '/config/global/cache/id_prefix', '') = x###FILE:../build.txt###_
-    
+
 Will read the content of ../build.txt and insert it in the id_prefix node: x72_
 
 ### Loops
@@ -275,20 +276,20 @@ Example:
 Disable all admin users:
 
     Est_Handler_Magento_AdminUserActivate('%', '%', '%') = 0
-    
+
 Enable user 'john.doe':
 
     Est_Handler_Magento_AdminUserActivate('john.doe', '%', '%') = 1
-    
+
 Enable user with email address 'info@example.com':
 
     Est_Handler_Magento_AdminUserActivate('%', 'info@example.com', '%') = 1
-    
+
 Enable all user with email addresses '...@example.com':
-    
+
     Est_Handler_Magento_AdminUserActivate('%', '%@example.com', '%') = 1
-    
-Enable all users with role 'Customer Service':    
+
+Enable all users with role 'Customer Service':
 
     Est_Handler_Magento_AdminUserActivate('%', '%', 'Customer Service') = 1
 


### PR DESCRIPTION
With these changes, the handler Est_Handler_Magento_CoreConfigData will insert or update the matching row with a real SQL NULL value when the user inserts 'null' or 'NULL' in the CSV file. The handler makes a strict distinction between "", " ", --empty--, 0 and NULL, updating the database row accordingly.

This PR solves issue #20.